### PR TITLE
add sim.py besides docker.sh

### DIFF
--- a/scripts/airframe_printer.sh
+++ b/scripts/airframe_printer.sh
@@ -64,23 +64,23 @@ PX4_VTOL_OCTOPLANE_13050="""
        /__________\ 
 """
 
-if [[ $1 == 4001 ]]; then
-  echo """
-      PX4 Quadrotor x
-          (4001)$PX4_QUADROTOR_X_4001"""
+# if [[ $1 == 4001 ]]; then
+#   echo """
+#       PX4 Quadrotor x
+#           (4001)$PX4_QUADROTOR_X_4001"""
 
-elif [[ $1 == 12001 ]]; then
-  echo """
-   PX4 Octorotor Coaxial
-          (12001)$PX4_OCTOROTOR_COAXIAL_12001"""
+# elif [[ $1 == 12001 ]]; then
+#   echo """
+#    PX4 Octorotor Coaxial
+#           (12001)$PX4_OCTOROTOR_COAXIAL_12001"""
 
-elif [[ $1 == 13000 ]]; then
-  echo """
-     PX4 Standard VTOL
-          (13000)$PX4_STANDARD_VTOL_13000"""
+# elif [[ $1 == 13000 ]]; then
+#   echo """
+#      PX4 Standard VTOL
+#           (13000)$PX4_STANDARD_VTOL_13000"""
 
-elif [[ $1 == 13050 ]]; then
-  echo """
-     PX4 VTOL Octoplane
-          (13050)$PX4_VTOL_OCTOPLANE_13050"""
-fi
+# elif [[ $1 == 13050 ]]; then
+#   echo """
+#      PX4 VTOL Octoplane
+#           (13050)$PX4_VTOL_OCTOPLANE_13050"""
+# fi

--- a/scripts/colors.py
+++ b/scripts/colors.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+class Colors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'

--- a/scripts/command.py
+++ b/scripts/command.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import os
+from dataclasses import dataclass
+from typing import Optional
+import yaml
+from mode import SimMode
+
+@dataclass
+class SimCommand:
+    name: str
+    alias: Optional[str]
+    mode: SimMode
+    info: Optional[str]
+    sim_config: Optional[str] = None
+
+    def check(self, name: str) -> bool:
+        return name in [self.name, self.alias]
+
+    @staticmethod
+    def create_from_yaml_file(file_path: str):
+        file_name = os.path.basename(file_path)
+        if not file_name.endswith(".yaml"):
+            return None
+
+        with open(file_path, 'r', encoding='utf-8') as stream:
+            yaml_data = yaml.safe_load(stream)
+        cmd = SimCommand(
+            name=file_name[:-5],
+            alias=yaml_data.get("alias"),
+            mode=SimMode.create_from_string(yaml_data.get("mode")),
+            info=yaml_data.get("info"),
+            sim_config=yaml_data.get("sim_config")
+        )
+        return cmd
+
+    @staticmethod
+    def create_list_from_directory(dir_with_yaml_files) -> list:
+        commands = []
+        all_files = sorted(os.listdir(dir_with_yaml_files), reverse=True)
+        for file_name in all_files:
+            file_path = os.path.join(dir_with_yaml_files, file_name)
+            cmd = SimCommand.create_from_yaml_file(file_path)
+            if cmd is not None:
+                commands.append(cmd)
+        return commands

--- a/scripts/docker_wrapper.py
+++ b/scripts/docker_wrapper.py
@@ -34,7 +34,9 @@ class DockerWrapper:
         if container_identifier is None:
             return
 
-        subprocess.run(["docker", "kill", container_identifier], check=True)
+        cmd = ["docker", "kill", container_identifier]
+        print(' '.join(cmd))
+        subprocess.run(cmd, check=True)
 
     @staticmethod
     def run_container(sniffer_path: str, image_name: str, sim_config: str, mode: SimMode):

--- a/scripts/docker_wrapper.py
+++ b/scripts/docker_wrapper.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import subprocess
+from typing import Optional
+from pathlib import Path
+from mode import SimMode
+
+class DockerWrapper:
+    COMMON_DOCKER_FLAGS = [
+        '--rm',
+        '--net=host',
+        '-v', '/tmp/.X11-unix:/tmp/.X11-unix:rw',
+        '-e', 'DISPLAY=:0',
+        '-e', 'QT_X11_NO_MITSHM=1',
+        '--privileged',
+    ]
+    REPOSITORY_DIR = Path(__file__).parent.parent.absolute()
+    DOCKERFILE_DIR = REPOSITORY_DIR
+    @staticmethod
+    def build(full_image_name : str) -> None:
+        cmd = ['docker', 'build', '-t', full_image_name, DockerWrapper.DOCKERFILE_DIR]
+        subprocess.run(cmd, check=True)
+
+    @staticmethod
+    def get_container_id_by_image_name(full_image_name: str) -> Optional[str]:
+        command = f"docker ps -q --filter ancestor={full_image_name}"
+        list_of_identifiers = subprocess.check_output(command, shell=True, text=True).splitlines()
+        if len(list_of_identifiers) == 0:
+            return None
+
+        return list_of_identifiers[0]
+
+    @staticmethod
+    def kill_container_by_id(container_identifier : str) -> None:
+        if container_identifier is None:
+            return
+
+        subprocess.run(["docker", "kill", container_identifier], check=True)
+
+    @staticmethod
+    def run_container(sniffer_path: str, image_name: str, sim_config: str, mode: SimMode):
+        if mode == SimMode.CYPHAL_HITL:
+            flags = [
+                *DockerWrapper.COMMON_DOCKER_FLAGS,
+                '-v', f'{sniffer_path}:{sniffer_path}',
+                '-e', f'CYPHAL_DEV_PATH_SYMLINK={sniffer_path}',
+            ]
+        elif mode == SimMode.DRONECAN_HITL:
+            flags = [
+                *DockerWrapper.COMMON_DOCKER_FLAGS,
+                '-v', f'{sniffer_path}:{sniffer_path}',
+                '-e', f'DRONECAN_DEV_PATH_SYMLINK={sniffer_path}',
+            ]
+        elif mode == SimMode.MAVLINK_SITL:
+            flags = [
+                *DockerWrapper.COMMON_DOCKER_FLAGS,
+            ]
+
+        command = [
+            "docker",
+            "container",
+            'run',
+            *flags,
+            image_name,
+            './scripts/run_sim.sh',
+            sim_config
+        ]
+
+        return subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/scripts/mode.py
+++ b/scripts/mode.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from enum import Enum
+
+class SimMode(Enum):
+    MONITOR = 0
+    CYPHAL_HITL = 1
+    DRONECAN_HITL = 2
+    MAVLINK_SITL = 3
+
+    @staticmethod
+    def create_from_string(string: str):
+        string_to_mode = {
+            "cyphal": SimMode.CYPHAL_HITL,
+            "dronecan": SimMode.DRONECAN_HITL,
+            "mavlink": SimMode.MAVLINK_SITL,
+            "monitor": SimMode.MONITOR,
+        }
+        return string_to_mode.get(string)

--- a/scripts/model.py
+++ b/scripts/model.py
@@ -36,7 +36,9 @@ class ContainerInfo:
 
 class AutopilotInterface:
     KNOWN_AUTOPILOTS = {
-        '/dev/serial/by-id/usb-3D_Robotics_PX4_FMU_v5.x_0' : "CUAV V5+",
+        '/dev/serial/by-id/usb-3D_Robotics_PX4_FMU_v5.x_0' : "PX4 CUAV V5+",
+        "/dev/serial/by-id/usb-Auterion_PX4_FMU_v6X.x_0" : "PX4 v6X",
+        "/dev/serial/by-id/usb-Auterion_PX4_FMU_v6C.x_0" : "PX4 v6C",
     }
     def __init__(self) -> None:
         self._autopilot = None

--- a/scripts/model.py
+++ b/scripts/model.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+import os
+import sys
+import time
+import glob
+import platform
+import subprocess
+from typing import Optional
+from dataclasses import dataclass
+from raccoonlab_tools.common.device_manager import DeviceManager
+from docker_wrapper import DockerWrapper
+from colors import Colors
+
+@dataclass
+class ContainerInfo:
+    version: str
+    architecture: str
+    id: Optional[int] = None
+    cpu_load_pct: Optional[int] = 0
+
+    @property
+    def full_name(self) -> str:
+        return f"ponomarevda/uavcan_hitl_dynamics_simulator:{self.version}{self.architecture}"
+
+    def update(self) -> bool:
+        self.id = DockerWrapper.get_container_id_by_image_name(self.full_name)
+        return False
+
+    def __str__(self) -> str:
+        if self.id is None:
+            string = f"{Colors.WARNING}None{Colors.ENDC}"
+        else:
+            string = f"{Colors.OKGREEN}{self.id}{Colors.ENDC}"
+        return string
+
+
+class AutopilotInterface:
+    KNOWN_AUTOPILOTS = {
+        '/dev/serial/by-id/usb-3D_Robotics_PX4_FMU_v5.x_0' : "CUAV V5+",
+    }
+    def __init__(self) -> None:
+        self._autopilot = None
+
+    def update(self) -> bool:
+        autopilot = None
+        for device_path, autopilot_type in AutopilotInterface.KNOWN_AUTOPILOTS.items():
+            connected_devices = glob.glob(device_path + '*')
+            for connected_device in connected_devices:
+                if os.path.exists(connected_device):
+                    autopilot = autopilot_type
+                    break
+
+        updated = autopilot != self._autopilot
+        self._autopilot = autopilot
+        return updated
+
+    @property
+    def autopilot_name(self) -> str:
+        return "Unknown" if self._autopilot is None else self._autopilot
+
+    def __str__(self) -> str:
+        if self._autopilot is None:
+            string = f"{Colors.WARNING}Unknown{Colors.ENDC}"
+        else:
+            string = f"{Colors.OKGREEN}{self._autopilot}{Colors.ENDC}"
+        return string
+
+class SnifferInterface:
+    def __init__(self) -> None:
+        self._transports = []
+
+    def update(self) -> bool:
+        try:
+            transports = DeviceManager.find_transports()
+        except (TypeError, IndexError):
+            transports = None
+
+        updated = transports != self._transports
+        self._transports = transports
+
+        return updated
+
+    @property
+    def sniffer(self) -> str:
+        if self._transports is None or len(self._transports) == 0:
+            transport = "Undefined"
+        else:
+            transport = self._transports[0].port
+        return transport
+
+    def __str__(self) -> str:
+        if self._transports is None or len(self._transports) == 0:
+            string = f"{Colors.WARNING}Not connected{Colors.ENDC}"
+        else:
+            string = f"{Colors.OKGREEN}{self._transports[0].port}{Colors.ENDC}"
+        return string
+
+class SimModel:
+    LOG_BUFFER_MAX_SIZE = 50
+
+    def __init__(self) -> None:
+        self._docker_info = ContainerInfo(
+            version=self._get_latest_tag(),
+            architecture=self._get_docker_architecture(),
+        )
+        self._elapsed_seconds = 0
+        self._start_time = time.time()
+        self._log_buffer = []
+        self._process = None
+        self._autopilot_interface = AutopilotInterface()
+        self._sniffer_interface = SnifferInterface()
+        self.update()
+
+    @property
+    def docker_info(self) -> ContainerInfo:
+        return self._docker_info
+
+    @property
+    def full_image_name(self) -> str:
+        return self._docker_info.full_name
+
+    @property
+    def autopilot_name(self) -> str:
+        return self._autopilot_interface.autopilot_name
+
+    @property
+    def log_buffer(self) -> list:
+        return self._log_buffer
+
+    @property
+    def transport(self) -> str:
+        return self._sniffer_interface.sniffer
+
+    @property
+    def time(self) -> int:
+        return self._elapsed_seconds
+
+    def update(self) -> bool:
+        """
+        Return True if model is updated and View should be updated, othwerwise False
+        """
+        self._update_process()
+        updated = (
+            self._update_elapsed_seconds() or
+            self._sniffer_interface.update() or
+            self._autopilot_interface.update() or
+            self._docker_info.update()
+        )
+        return updated
+
+    def add_process(self, process: subprocess.Popen) -> None:
+        assert isinstance(process, subprocess.Popen)
+        self._process = process
+
+    @staticmethod
+    def _get_latest_tag() -> str:
+        cmd = "git describe --tags --abbrev=0"
+        return subprocess.check_output(cmd, shell=True, text=True).strip()
+
+    @staticmethod
+    def _get_docker_architecture() -> str:
+        architecture = platform.machine()
+
+        if 'aarch64' in architecture:
+            docker_architecture = 'arm64'
+        elif 'x86_64' in architecture:
+            docker_architecture = 'amd64'
+        else:
+            print("Unknown architecture")
+            sys.exit()
+
+        return docker_architecture
+
+    def _update_elapsed_seconds(self) -> bool:
+        elapsed_seconds = int(time.time() - self._start_time)
+        updated = self._elapsed_seconds != elapsed_seconds
+        self._elapsed_seconds = elapsed_seconds
+        return updated
+
+    def _update_process(self) -> bool:
+        if self._process is None:
+            return False
+
+        output = self._process.stdout.readline()
+        if output == b'' and self._process.poll() is not None:
+            return False
+
+        if output:
+            self._log_buffer.append(output.strip().decode())
+        if len(self._log_buffer) > SimModel.LOG_BUFFER_MAX_SIZE:
+            self._log_buffer.pop(0)
+
+        return True
+
+    def __str__(self) -> str:
+        _, columns = os.popen('stty size', 'r').read().split()
+        separator = "-" * int(columns)
+
+        return (
+            f"UAV HITL Simulator {self.docker_info.version} ({self.docker_info.architecture})\n"
+            f"{separator}\n"
+            f"Sniffer      : {self._sniffer_interface}\n"
+            f"Autopilot    : {self._autopilot_interface}\n"
+            f"Container    : {self.docker_info}\n"
+            f"Command      : ?\n"
+            f"Time         : {self.time}\n"
+            f"{separator}\n"
+        )
+
+def main():
+    model = SimModel()
+    while model.time < 60:
+        if not model.update():
+            continue
+        print("\033c" + str(model))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sim.py
+++ b/scripts/sim.py
@@ -16,8 +16,9 @@
 import os
 import sys
 import time
+import logging
+import datetime
 from typing import Optional
-from pathlib import Path
 
 from argparse import ArgumentParser, RawTextHelpFormatter
 from configurator import configure
@@ -25,8 +26,12 @@ from command import SimCommand
 from docker_wrapper import DockerWrapper
 from model import SimModel
 
-REPOSITORY_DIR = Path(__file__).parent.parent.absolute()
-VEHICLES_DIR = f"{REPOSITORY_DIR}/configs/vehicles"
+REPO_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+VEHICLES_DIR = os.path.join(REPO_DIR, "configs", "vehicles")
+BINARY_OUTPUT_PATH = os.path.join(REPO_DIR, "firmware.bin")
+LOG_FILENAME = f"log_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.log"
+LOG_PATH = os.path.join(REPO_DIR, "logs", LOG_FILENAME)
+
 COMMANDS = [
     SimCommand(name="build", alias='b', mode=None, info="Build the Docker image"),
     SimCommand(name="kill", alias='', mode=None, info="Kill the running Docker container"),
@@ -102,6 +107,16 @@ class SimView:
 
 
 def main():
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                        filename=LOG_PATH,
+                        filemode='w')
+    console = logging.StreamHandler()
+    console.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+    console.setFormatter(formatter)
+    logging.getLogger().addHandler(console)
+
     parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
 
     command_help = f'{"Command":<36} {"Alias":<10} {"Info"}\n'

--- a/scripts/sim.py
+++ b/scripts/sim.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+  UAV Cyphal/DroneCAN HITL Simulator is Hardware In The Loop simulator for PX4
+  quadcopters and VTOLs. It works in such a way that the hardware knows nothing
+  about the simulation. It covers more modules than standard SITL and HITL.
+
+  sim.py is an interactive CLI for working with the UAV HITL Simulator with
+  Docker. It automatically does:
+  1. Set all the necessary Docker flags,
+  2. Find the autopilot, upload the firmware and parameters to it,
+  3. Find CAN-sniffer and create SLCAN/Socketcan interface,
+  4. Configure and run the core HITL simulator.
+
+  More details: https://github.com/ZilantRobotics/innopolis_vtol_dynamics
+"""
+import os
+import sys
+import time
+from typing import Optional
+from pathlib import Path
+
+from argparse import ArgumentParser, RawTextHelpFormatter
+from configurator import configure
+from command import SimCommand
+from docker_wrapper import DockerWrapper
+from model import SimModel
+
+REPOSITORY_DIR = Path(__file__).parent.parent.absolute()
+VEHICLES_DIR = f"{REPOSITORY_DIR}/configs/vehicles"
+COMMANDS = [
+    SimCommand(name="build", alias='b', mode=None, info="Build the Docker image"),
+    SimCommand(name="kill", alias='', mode=None, info="Kill the running Docker container"),
+    SimCommand(name="monitor", alias='', mode=None, info="Just monitor"),
+    *SimCommand.create_list_from_directory(dir_with_yaml_files=VEHICLES_DIR)
+]
+
+class SimCommander:
+    def __init__(self, model: SimModel) -> None:
+        assert isinstance(model, SimModel)
+        self._model = model
+
+    def __del__(self):
+        self._kill()
+
+    def execute(self, command: SimCommand, upload_firmware: bool, configure_params: bool) -> None:
+        assert isinstance(command, SimCommand)
+
+        if command.name == "kill":
+            self._kill()
+            sys.exit(0)
+
+        if command.name == "build":
+            self._build()
+            sys.exit(0)
+
+        if upload_firmware or configure_params:
+            config_path = f"{VEHICLES_DIR}/{command.name}.yaml"
+            configure(config_path, upload_firmware, configure_params)
+
+        if command.mode is None:
+            return
+
+        try:
+            self._kill()
+            process = DockerWrapper.run_container(sniffer_path=self._model.transport,
+                                                  image_name=self._model.full_image_name,
+                                                  sim_config=command.sim_config,
+                                                  mode=command.mode)
+            self._model.add_process(process)
+        except Exception:
+            self._kill()
+
+    def _kill(self) -> None:
+        DockerWrapper.kill_container_by_id(self._model.docker_info.id)
+
+    def _build(self) -> None:
+        DockerWrapper.build(self._model.full_image_name)
+
+class SimView:
+    def __init__(self, model: SimModel) -> None:
+        assert isinstance(model, SimModel)
+        self.model = model
+
+    def process(self, command: Optional[str]) -> None:
+        assert isinstance(command, str) or command is None
+
+        if not self.model.update():
+            return
+
+        rows, _ = os.popen('stty size', 'r').read().split()
+        max_log_rows = int(rows) - 11
+        os.system('clear')
+        print("\033c" + str(self.model))
+
+        log_buffer = self.model.log_buffer
+        if len(log_buffer) <= 0:
+            return
+
+        for line in log_buffer[-max_log_rows:]:
+            print(line)
+        print("--------------------------------------------------------------------------------")
+
+
+def main():
+    parser = ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
+
+    command_help = f'{"Command":<36} {"Alias":<10} {"Info"}\n'
+    command_help += '\n'.join([f"{cmd.name:<36} {cmd.alias:<10} {cmd.info}" for cmd in COMMANDS])
+    parser.add_argument('command', help=command_help)
+
+    upload_help = ("upload the required firmware")
+    parser.add_argument("--upload", help=upload_help, default=False, action='store_true')
+
+    configure_help = ("reset all the parameters to default and configure")
+    parser.add_argument("--configure", help=configure_help, default=False, action='store_true')
+
+    force_help = ("both upload and then configure")
+    parser.add_argument("--force", help=force_help, default=False, action='store_true')
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
+    args = parser.parse_args()
+
+    if args.force:
+        args.upload = True
+        args.configure = True
+
+    command = next((cmd for cmd in COMMANDS if cmd.check(args.command)), None)
+    if command is None:
+        print(f"Unknown command {args.command}.")
+        parser.print_help()
+        sys.exit(1)
+
+    model = SimModel()
+    view = SimView(model)
+    commander = SimCommander(model=model)
+    commander.execute(command, args.upload, args.configure)
+
+    try:
+        while True:
+            view.process(command.name)
+            time.sleep(0.01)
+    except KeyboardInterrupt:
+        print("KeyboardInterrupt")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
sim.py introduces better interaction with the simulator.
- [x] separate force into 2 options: upload and configure
- [x] container should be killed with ctrl+c withing sim.py
- [x] besides sim logs display the general sim state:
  - is sniffer connected,
  - is autopilot connected,
  - version of the simulator,
  - running docker container id